### PR TITLE
Add foundational DocuNest documentation scaffold

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright (c) 2025 Qiyun Dai
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+DocuNest
+Copyright (c) 2025 Qiyun Dai
+
+This product includes software developed by the DocuNest contributors.
+Licensed under the Apache License, Version 2.0.

--- a/docs/adr/0001-architecture-decision.md
+++ b/docs/adr/0001-architecture-decision.md
@@ -1,0 +1,30 @@
+---
+adr_id: "0001"
+title: "Core Architecture Decision"
+date: "2025-10-06"
+status: "accepted"
+---
+# ADR 0001 — Core Architecture Choice
+
+## Context
+
+DocuNest requires a scalable, open-source framework for manual ingestion, structured storage, and contextual AI.
+
+## Decision
+
+Adopt a **TypeScript monorepo** with:
+
+* Next.js (web) + React Native (mobile)
+* Node + tRPC backend
+* PostgreSQL + pgvector
+* Redis + BullMQ
+* MinIO / S3
+* Docker Compose (optional Kubernetes)
+* AI providers via plugins (OpenAI/Ollama)
+
+## Consequences
+
+✅ Unified types and runtime
+✅ Easy self-hosting via Compose
+✅ Scalable for Kubernetes
+🧩 Extensible via plugins

--- a/docs/context/01-overview.md
+++ b/docs/context/01-overview.md
@@ -1,0 +1,27 @@
+---
+title: "DocuNest — Open-Core Initiative Overview"
+last_updated: "2025-10-06"
+author: "Qiyun Dai"
+stage: "Open-source foundation planning (Phase 1)"
+---
+# 🧭 DocuNest — Open-Core Initiative
+
+## Vision
+DocuNest is an **open-source, privacy-first infrastructure** for digitizing product documentation, customer support, and brand engagement — reimagining the user manual as a living, contextual, AI-powered ecosystem.
+
+**Mission:**  
+Build the world’s unified platform where every product’s knowledge — manuals, tutorials, recalls, and updates — lives sustainably, intelligently, and accessibly.
+
+## Core Value Propositions
+| Stakeholder | Pain Today | DocuNest Solution |
+|--------------|-------------|------------------|
+| **Consumers** | Hard-to-find manuals, scattered info | Unified app for owned products, AI Q&A, recall alerts |
+| **Businesses** | Costly printing, inconsistent support | Centralized digital doc hub, analytics, AI chat |
+| **Planet** | Paper waste, logistics emissions | Fully digital manuals = less material use |
+
+## Foundational Principles
+1. **Data Sovereignty** – Businesses and users own their data.  
+2. **Open Source** – Released under a permissive license (Apache 2.0 preferred).  
+3. **Sustainability** – Replace printed manuals globally.  
+4. **Neutral Infrastructure** – Brand-agnostic and auditable.  
+5. **Intelligence with Context** – AI grounded strictly in verified documentation.

--- a/docs/context/02-architecture.md
+++ b/docs/context/02-architecture.md
@@ -1,0 +1,88 @@
+---
+title: "DocuNest Technical Architecture"
+version: "0.1"
+last_updated: "2025-10-06"
+---
+# ⚙️ Technical Architecture (v0.1)
+
+## 1. System Overview
+DocuNest is a **multi-tenant platform** that ingests product manuals, converts them into structured JSON, and serves them via web/mobile apps and APIs.  
+It features contextual AI, service/recall tracking, and engagement tools.
+
+## 2. Core Services
+- web/ – Next.js portal (viewer + admin)
+- app/ – React Native client
+- api/ – Node + tRPC gateway
+- worker/ – BullMQ jobs (ingest, embed, email, recall)
+- vector/ – pgvector or Qdrant
+- db/ – PostgreSQL (source of truth)
+- files/ – MinIO / S3 storage
+- proxy/ – Caddy / Traefik
+- plugins/ – AI, auth, analytics, and theme adapters
+
+## 3. Data Flow
+1. Ingest → Parse → Normalize → Store as *Manual Schema v0.1*  
+2. Embed → Chunk + vectorize → store in pgvector/Qdrant  
+3. Search / AI → Retrieve + generate contextual response with citations  
+4. Service & Recall → Link registered products → notify users  
+5. Engage → Publish blog/poll/newsletter → deliver to subscribers  
+6. Analytics → Collect anonymized metrics per tenant  
+
+## 4. Core Domain Model
+Tenant • User • Product • Manual • ManualSection • EmbeddingChunk • Registration • Recall • Article/Poll • Subscription • Ticket
+
+## 5. Manual Schema v0.1
+**Example JSON structure**
+```json
+{
+  "manualId": "uuid",
+  "product": { "model": "X100", "sku": "123" },
+  "version": "1.0.0",
+  "locale": "en-US",
+  "sections": [
+    {
+      "id": "safety",
+      "title": "Safety",
+      "body": [
+        { "type": "paragraph", "text": "Handle with care and keep away from heat sources." }
+      ]
+    }
+  ]
+}
+```
+
+## 6. API Routers (tRPC)
+
+* auth – authentication and tenant login
+* docs – manuals, sections, metadata
+* search – hybrid and vector search
+* ai – RAG query interface
+* service – registration, recall endpoints
+* engage – articles, polls, newsletters
+* admin – ingestion, publishing, analytics
+
+Example: `ai.ask({ q, productId, version?, locale? }) → { stream, citations }`
+
+## 7. Deployment
+
+Default stack: web, api, worker, db, vector, files, queue, proxy.
+Optional Kubernetes manifests for scale.
+Monitoring: OpenTelemetry, Prometheus, Grafana.
+Nightly backups for DB, vector, and file storage.
+
+## 8. Security
+
+* Row-level multi-tenancy (tenantId scope)
+* JWT auth with RBAC
+* Strict CSP & signed URLs
+* Virus scan uploads (ClamAV container)
+* No third-party trackers
+
+## 9. Extensibility
+
+Plugin interfaces:
+
+* AIProvider – embeddings & completion logic
+* AuthProvider – auth sources
+* AnalyticsAdapter – event pipeline
+* ThemePack – colors & layout overrides

--- a/docs/context/03-codex.md
+++ b/docs/context/03-codex.md
@@ -1,0 +1,49 @@
+---
+title: "DocuNest Codex Context"
+purpose: "Enable Cursor/Codex to understand project structure and development flow"
+---
+# 🤖 DocuNest — Codex Context
+
+## Project Goal
+
+Build the **open-core** of DocuNest:
+
+* Manual ingestion → schema → search → RAG API
+* Add Service/Recall + Engage skeletons
+* Multi-tenant, privacy-first, self-hostable
+
+## Stack Overview
+
+TypeScript (strict), Node 20, PNPM workspaces
+Next.js + React Native + tRPC + Prisma + pgvector/Qdrant + Redis + MinIO + Caddy
+
+## Repository Layout
+
+apps/{web,app,api,worker}
+packages/{schema,ui,plugins,utils}
+infra/{compose,k8s}
+docs/{context,adr,setup}
+
+## Environment Variables
+
+Example:
+
+```
+DATABASE_URL=postgres://postgres:postgres@db:5432/docunest
+VECTOR_BACKEND=pgvector
+S3_ENDPOINT=http://files:9000
+S3_BUCKET=docunest
+AI_PROVIDER=openai
+OPENAI_API_KEY=sk-...
+```
+
+## Week-0 Tasks
+
+1. Scaffold monorepo
+2. Implement Schema v0.1
+3. Setup Prisma models
+4. Ingest CLI prototype
+5. Chunk + embed pipeline
+6. Expose `search.query` + `ai.ask`
+7. Build Next.js viewer
+8. Compose up demo stack

--- a/docs/setup/docker-compose.md
+++ b/docs/setup/docker-compose.md
@@ -1,0 +1,25 @@
+---
+title: "Docker Compose Overview"
+---
+# 🐳 Docker Compose Overview
+
+| Service | Description      |
+| ------- | ---------------- |
+| db      | PostgreSQL 16    |
+| vector  | Qdrant vector DB |
+| files   | MinIO            |
+| queue   | Redis 7          |
+| api     | Node + tRPC      |
+| worker  | BullMQ jobs      |
+| web     | Next.js          |
+| proxy   | Caddy            |
+
+Volumes: db_data, qdrant_data, minio_data
+Ports: web:3000, api:4000, qdrant:6333, minio:9000, proxy:8443
+
+Example:
+
+```bash
+cd infra/compose
+docker-compose up -d
+```

--- a/docs/setup/local-dev.md
+++ b/docs/setup/local-dev.md
@@ -1,0 +1,11 @@
+---
+title: "Local Development Setup"
+---
+# 🧰 Local Development Setup
+
+1. Clone the repository
+2. Copy `.env.example` → `.env` and fill in keys
+3. Run `docker-compose up -d` from `infra/compose`
+4. Run `pnpm dev` (web:3000, api:4000)
+5. Seed database: `pnpm run db:seed`
+6. Open [http://localhost:3000](http://localhost:3000) and test Ask AI.


### PR DESCRIPTION
## Summary
- add contextual overview, architecture, and codex guides with YAML front matter
- capture initial architecture decision and local/docker setup instructions
- update the repository with the Apache 2.0 license text and NOTICE attribution

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3acfdc03c8329b0447f24205b1595