### PR TITLE
Update CI workflow to use Corepack-enabled pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8.15.4
-
-      - name: Setup Node.js
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile=false
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+          pnpm --version
+
+      - name: Install deps (create lockfile if missing)
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Format
+        run: pnpm format
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
## Summary
- replace pnpm/action-setup with Corepack-based pnpm enablement
- install dependencies without requiring an existing lockfile and add formatting step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43ba6ccd883298c05b08bd526bb7a