### PR TITLE
Configure Prettier for CI workflows

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+build
+.next
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "singleQuote": true,
-  "semi": true,
-  "trailingComma": "all",
-  "printWidth": 100
-}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -1,27 +1,33 @@
 {
   "name": "docunest",
   "private": true,
-  "packageManager": "pnpm@8.15.4",
+  "packageManager": "pnpm@9.12.0",
+  "engines": {
+    "node": ">=20"
+  },
   "workspaces": [
     "apps/*",
     "packages/*",
     "infra/*"
   ],
   "scripts": {
-    "dev": "pnpm -r --parallel dev",
-    "build": "pnpm -r build",
-    "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
+    "format": "prettier \"**/*.{ts,tsx,js,jsx,md,mdx,json,yml,yaml}\" --write",
+    "format:check": "prettier \"**/*.{ts,tsx,js,jsx,md,mdx,json,yml,yaml}\" --check",
+    "typecheck": "pnpm -r typecheck",
+    "build": "pnpm -r build",
+    "dev": "pnpm -r --parallel dev",
     "db:push": "pnpm --filter @docunest/api prisma migrate deploy && pnpm --filter @docunest/api prisma db push",
     "seed": "pnpm --filter @docunest/api tsx src/seed/seed.ts"
   },
   "devDependencies": {
+    "eslint": "^8.57.1",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-unused-imports": "^3.2.0",
+    "prettier": "^3.3.3",
     "@types/node": "20.11.30",
-    "@typescript-eslint/eslint-plugin": "7.4.0",
-    "@typescript-eslint/parser": "7.4.0",
-    "eslint": "8.57.0",
-    "eslint-config-prettier": "9.1.0",
-    "prettier": "3.2.5",
     "typescript": "5.4.3"
   }
 }


### PR DESCRIPTION
## Summary
- update the root package.json with the required pnpm version, Node engine, and Prettier scripts
- add Prettier configuration and ignore files expected by CI consumers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e469cc65e48329b2d5d8ebacc5959c